### PR TITLE
Fix gem to allow using Ruby 3.0.

### DIFF
--- a/lib/webmock-rspec-helper/version.rb
+++ b/lib/webmock-rspec-helper/version.rb
@@ -1,7 +1,7 @@
 module WebMock
   module RSpec
     module Helper
-      VERSION = '0.0.5'.freeze
+      VERSION = '0.0.6'.freeze
     end
   end
 end

--- a/spec/webmock-rspec-helper_spec.rb
+++ b/spec/webmock-rspec-helper_spec.rb
@@ -15,35 +15,35 @@ end
 
 describe '#webmock' do
   it 'mocks GET google using default response 200' do
-    webmock :get, %r{google.com} => 'GET_google.json'
+    webmock :get, { %r{google.com} => 'GET_google.json' }
     response = GET 'http://google.com'
     expect(response.status).to eq 200
     expect(response.body['google']).to eq true
   end
 
   it 'mocks GET google with custom response code' do
-    webmock :get, %r{google.com} => 'GET_google.999.json'
+    webmock :get, { %r{google.com} => 'GET_google.999.json' }
     response = GET 'http://google.com'
     expect(response.status).to eq 999
     expect(response.body['google']).to eq true
   end
 
   it 'accepts a block that returns the with options' do
-    webmock :get, %r{google.com} => 'GET_google.json', with: Hash[query: { test: '123' }]
+    webmock :get, { %r{google.com} => 'GET_google.json' }, with: Hash[query: { test: '123' }]
     expect { GET 'http://google.com' }.to raise_error WebMock::NetConnectNotAllowedError
     response = GET 'http://google.com?test=123'
     expect(response.status).to eq 200
   end
 
   it 'mocks GET google with an empty body and given status code' do
-    webmock :get, %r{google.com} => 204
+    webmock :get, { %r{google.com} => 204 }
     response = GET 'http://google.com'
     expect(response.body).to eq ''
     expect(response.status).to eq 204
   end
 
   it 'mocks GET google with response headers' do
-    webmock :get, %r{google.com} => 'GET_google.json', headers: { 'Content-Type' => 'text/html' }
+    webmock :get, { %r{google.com} => 'GET_google.json' }, headers: { 'Content-Type' => 'text/html' }
     response = GET 'http://google.com'
     expect(response.content_type).to eq 'text/html'
   end

--- a/webmock-rspec-helper.gemspec
+++ b/webmock-rspec-helper.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '~> 2'
+  spec.required_ruby_version = '>= 2.0', '< 4.0'
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
I did some simple modifications to make the gem compatible with ruby 3.0. In all tests I did it was compatible before only until ruby 2.7.

Ruby 3.0 has a restriction that prevents the way method webmock was being called. It was considering the hash's key as a named parameter. The way it is now, it's clear it is a hash and ruby 3 doesn't generate errors.